### PR TITLE
feat: 自动化发布流程，推送标签时自动创建 Release

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -92,17 +92,17 @@ git tag -a vx.y.z -m "Release vx.y.z"
 git push origin vx.y.z
 ```
 
-### 6. 创建 GitHub Release
-- 使用 GitHub API 创建 Release
-- 标签：`vx.y.z`
-- 标题：`Release vx.y.z` 或自定义标题
-- 内容：第 4 步生成的 Release Notes
-- 发布后，GitHub Actions 会自动触发 PyPI 发布
+**推送标签后会自动触发**：
+1. 构建 Python 包
+2. 发布到 PyPI
+3. 创建 GitHub Release（从 CHANGELOG.md 提取发布说明）
+4. 上传构建产物（wheel 和 sdist）到 Release
 
-### 7. 验证发布
+### 6. 验证发布
 - 等待 GitHub Actions 完成（检查 workflow 状态）
-- 提供 PyPI 链接：`https://pypi.org/project/hyperliquid-mcp-python/x.y.z/`
-- 提供 GitHub Release 链接
+- 验证 PyPI 发布：`https://pypi.org/project/hyperliquid-mcp-python/x.y.z/`
+- 验证 GitHub Release：`https://github.com/talkincode/hyperliquid-mcp-python/releases/tag/vx.y.z`
+- 确认 Release 包含构建产物附件
 
 ## 注意事项
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 jobs:
@@ -11,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write  # 需要写权限来创建 Release
     
     steps:
     - uses: actions/checkout@v5
@@ -36,3 +37,34 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+    
+    - name: Extract version from tag
+      id: get_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+    
+    - name: Generate release notes
+      id: release_notes
+      run: |
+        # 读取 CHANGELOG.md 中当前版本的内容
+        VERSION=${{ steps.get_version.outputs.VERSION }}
+        if [ -f CHANGELOG.md ]; then
+          # 提取当前版本的变更日志
+          awk "/## \[${VERSION}\]/,/## \[/" CHANGELOG.md | sed '$d' > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "Release v${VERSION}" > release_notes.md
+          fi
+        else
+          echo "Release v${VERSION}" > release_notes.md
+        fi
+    
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release v${{ steps.get_version.outputs.VERSION }}
+        body_path: release_notes.md
+        files: |
+          dist/*
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# 自动化发布流程改进

## 🚀 功能改进

### 主要变更

1. **修改 `publish.yml` 工作流**
   - ✅ 触发器从 `release.published` 改为 `push.tags: v*.*.*`
   - ✅ 推送标签时自动触发构建和发布
   - ✅ 自动从 `CHANGELOG.md` 提取当前版本的发布说明
   - ✅ 自动创建 GitHub Release
   - ✅ 自动上传构建产物（wheel 和 sdist）到 Release

2. **更新 `release.prompt.md`**
   - 📝 简化发布流程说明
   - 📝 说明自动化行为
   - 📝 移除手动创建 Release 的步骤

### 优势

- **简化流程**：只需推送标签，无需手动创建 Release
- **自动化**：构建、发布、创建 Release 全自动
- **一致性**：Release 说明自动从 CHANGELOG.md 提取
- **可追溯**：所有构建产物自动附加到 Release

### 工作流程

```bash
# 1. 合并 release PR 到 main
# 2. 切换到 main 并拉取最新代码
git checkout main && git pull

# 3. 创建并推送标签（触发自动发布）
git tag -a v0.1.7 -m "Release v0.1.7"
git push origin v0.1.7

# 4. 等待 GitHub Actions 完成：
#    ✅ 构建包
#    ✅ 发布到 PyPI
#    ✅ 创建 GitHub Release
#    ✅ 上传构建产物
```

## 测试

此 PR 本身不会触发发布。待合并后，下次发布 (v0.1.7) 将测试新的自动化流程。

## 相关 Issue

改进当前的发布流程，使其更加自动化和可靠。