### PR TITLE
fix: 修复 mkdocs.yml 中 emoji 配置的 YAML 格式

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,8 +64,8 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.emoji:
-    emoji_index: "material.extensions.emoji.twemoji"
-    emoji_generator: "material.extensions.emoji.to_svg"
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - md_in_html
   - tables


### PR DESCRIPTION
## 🐛 问题描述

MkDocs 配置文件中的 emoji 扩展配置使用了错误的 YAML 格式,导致构建时可能出现解析错误。

## 🔧 修复内容

- 将 `emoji_index` 和 `emoji_generator` 从字符串格式改为使用 `!!python/name` 语法
- 修复了缩进问题,确保 YAML 语法正确
- 这是 MkDocs Material 主题推荐的配置方式

## 📝 变更详情

```yaml
# 之前(错误)
emoji_index: "material.extensions.emoji.twemoji"
emoji_generator: "material.extensions.emoji.to_svg"

# 之后(正确)
emoji_index: !!python/name:material.extensions.emoji.twemoji
emoji_generator: !!python/name:material.extensions.emoji.to_svg
```

## ✅ 测试

- [x] YAML 语法检查通过
- [x] Pre-commit hooks 全部通过
- [x] MkDocs 构建测试成功

## 📚 参考

- [MkDocs Material - Emoji 配置文档](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration)